### PR TITLE
Add support for custom kernels

### DIFF
--- a/09_slackware_linux
+++ b/09_slackware_linux
@@ -158,3 +158,8 @@ list=`for i in /boot/vmlinu[xz]-huge-* /vmlinu[xz]-huge-* ; do
         if grub_file_is_not_garbage "$i" ; then echo -n "$i " ; fi
       done`
 process_list "${list}" "huge" "false"
+
+list=`for i in /boot/vmlinu[xz]-custom-* /vmlinu[xz]-custom-* ; do
+        if grub_file_is_not_garbage "$i" ; then echo -n "$i " ; fi
+      done`
+process_list "${list}" "custom" "true"


### PR DESCRIPTION
Thanks for your modifications @Richard-Cranium . Have been using them for a long time.

This PR adds support for custom kernels installed, eg `/boot/vmlinuz-custom-4.9.184` .